### PR TITLE
Import Buffer explicitly for browser runtimes

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -83,6 +83,7 @@ var engines_default = engines;
 // src/utils.ts
 import stripBom from "strip-bom-string";
 import typeOf from "kind-of";
+import { Buffer } from "buffer";
 var utils = {
   define: (obj, key, val) => {
     Reflect.defineProperty(obj, key, {
@@ -313,7 +314,7 @@ var matterDict = {
       closeIndex = len;
     }
     f.matter = f.content.slice(0, closeIndex);
-    const block = f.matter.replace(/^\s*#[^\n]+/gm, "").trim();
+    const block = f.matter.replaceAll(/^\s*#[^\n]+/gm, "").trim();
     if (block === "") {
       f.isEmpty = true;
       f.empty = f.content;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,6 @@
 import stripBom from "strip-bom-string";
 import typeOf from "kind-of";
+import { Buffer } from "node:buffer";
 
 export const utils = {
   define: (obj: any, key: any, val: any) => {


### PR DESCRIPTION
The built in Node `Buffer` is being used implicitly in the `toBuffer()` function. Importing it explicitly allows for shimming in browser runtimes, or other non-Node runtimes like Cloudflare Workers.